### PR TITLE
Corrected CPU details (top_right) title

### DIFF
--- a/src/components/cpu_monitor.rs
+++ b/src/components/cpu_monitor.rs
@@ -33,7 +33,7 @@ pub fn cpu_monitor(state: &mut State) -> List {
         Block::default()
             .borders(Borders::all())
             .border_type(BorderType::Plain)
-            .title("System"),
+            .title("CPU"),
     );
     return component;
 }


### PR DESCRIPTION
The top_right area was for CPU details. It was named System rather than CPU.